### PR TITLE
Laravel 11 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^9.0|^10.0",
+        "illuminate/contracts": "^9.0|^10.0|^11.0",
         "guzzlehttp/guzzle": "^7.5",
         "spatie/laravel-package-tools": "^1.14.0",
         "web-token/jwt-checker": "^3.0",


### PR DESCRIPTION
Laravel 11 requires illuminate/contracts 11 or higher.  Updated this dependency and tests passing.