### PR TITLE
Allow Validation of CF Access Service Tokens

### DIFF
--- a/src/ZeroTrustMiddleware.php
+++ b/src/ZeroTrustMiddleware.php
@@ -21,6 +21,7 @@ use Jose\Component\Checker\NotBeforeChecker;
 use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Signature\Algorithm\RS256;
+use Jose\Component\Signature\JWS;
 use Jose\Component\Signature\JWSTokenSupport;
 use Jose\Component\Signature\JWSVerifier;
 use Jose\Component\Signature\Serializer\CompactSerializer;
@@ -40,7 +41,9 @@ class ZeroTrustMiddleware
 
     public const CERTIFICATE_CACHE_KEY = 'cloudflare-zero-trust-middleware-certificate-cache';
 
-    final public const CLAIMS = ['iss', 'sub', 'aud', 'exp', 'nbf', 'country', 'identity_nonce', 'type'];
+    final public const USER_CLAIMS = ['iss', 'sub', 'aud', 'exp', 'nbf', 'country', 'identity_nonce', 'type'];
+
+    final public const SERVICE_TOKEN_CLAIMS = ['iss', 'aud', 'exp', 'type', 'common_name'];
 
     /**
      * Handle an incoming request.
@@ -80,25 +83,40 @@ class ZeroTrustMiddleware
         return $next($request);
     }
 
-    protected function getClaims(): array
+    protected function getClaims(JWS $jws): array
     {
-        return self::CLAIMS;
+        $payload = json_decode($jws->getPayload(), true);
+
+        // User JWTs have an email claim, service tokens have common_name
+        if (isset($payload['email'])) {
+            return self::USER_CLAIMS;
+        }
+
+        // Default to service token claims (includes common_name and minimal set)
+        return self::SERVICE_TOKEN_CLAIMS;
     }
 
     /**
      * @throws \DateInvalidTimeZoneException
      */
-    protected function getClaimCheckers(): array
+    protected function getClaimCheckers(JWS $jws): array
     {
+        $payload = json_decode($jws->getPayload(), true);
         $clock = new NativeClock(new DateTimeZone('UTC'));
 
-        return [
+        $checkers = [
             new IssuedAtChecker(clock: $clock),
             new IssuerChecker(['https://'.config('cloudflare-zero-trust-middleware.cloudflare_team_name').'.cloudflareaccess.com']),
-            new NotBeforeChecker(clock: $clock),
             new ExpirationTimeChecker(clock: $clock),
             new AudienceChecker(config('cloudflare-zero-trust-middleware.cloudflare_zero_trust_application_audience_tag')),
         ];
+
+        // Only check NotBeforeChecker for user JWTs (they have the nbf claim)
+        if (isset($payload['email'])) {
+            $checkers[] = new NotBeforeChecker(clock: $clock);
+        }
+
+        return $checkers;
     }
 
     /**
@@ -130,10 +148,10 @@ class ZeroTrustMiddleware
 
         $headerCheckerManager->check($jws, 0, ['kid', 'alg']);
 
-        $claimCheckerManager = new ClaimCheckerManager($this->getClaimCheckers());
+        $claimCheckerManager = new ClaimCheckerManager($this->getClaimCheckers($jws));
 
         $claims = json_decode($jws->getPayload(), true);
-        $claimCheckerManager->check($claims, $this->getClaims());
+        $claimCheckerManager->check($claims, $this->getClaims($jws));
 
         // We must verify the signature with the correct key
         $key_id_used_for_sig = $jws->getSignature(0)->getProtectedHeaderParameter('kid');

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -1,5 +1,9 @@
 <?php
 
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Signature\Algorithm\RS256;
+use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\Serializer\CompactSerializer;
 use Teraone\ZeroTrustMiddleware\ZeroTrustMiddleware;
 
 it('throws if no header given', function (): void {
@@ -59,6 +63,193 @@ it('will authenticate with second key', function (): void {
 it('will not authenticate with an unknown key', function (): void {
     $this->withHeaders([
         ZeroTrustMiddleware::CF_ACCESS_JWT_HEADER_NAME => $this->generateJwtFromUnknownKey('aud', now()->addHours(5)),
+    ])
+        ->getJson('/')
+        ->assertStatus(401);
+});
+
+it('authenticates with valid user JWT containing all required user claims', function (): void {
+    $this->withHeaders([
+        ZeroTrustMiddleware::CF_ACCESS_JWT_HEADER_NAME => $this->generateUserJWT('aud', now()->addYear(), $this->jwk_1),
+    ])
+        ->getJson('/')
+        ->assertStatus(200);
+});
+
+it('authenticates with valid service token JWT', function (): void {
+    $this->withHeaders([
+        ZeroTrustMiddleware::CF_ACCESS_JWT_HEADER_NAME => $this->generateServiceTokenJWT('aud', now()->addYear(), $this->jwk_1),
+    ])
+        ->getJson('/')
+        ->assertStatus(200);
+});
+
+it('rejects user JWT missing sub claim', function (): void {
+    $this->withHeaders([
+        ZeroTrustMiddleware::CF_ACCESS_JWT_HEADER_NAME => $this->generateUserJWT('aud', now()->addYear(), $this->jwk_1, ['sub' => null]),
+    ])
+        ->getJson('/')
+        ->assertStatus(401);
+});
+
+it('rejects user JWT missing nbf claim', function (): void {
+    $payload = [
+        'aud' => ['aud'],
+        'email' => 'user@example.com',
+        'exp' => now()->addYear()->timestamp,
+        'iat' => now()->subSecond()->timestamp,
+        'iss' => 'https://'.config('cloudflare-zero-trust-middleware.cloudflare_team_name').'.cloudflareaccess.com',
+        'type' => 'user',
+        'identity_nonce' => 'nonce123',
+        'sub' => 'user-sub-123',
+        'country' => 'US',
+    ];
+
+    $algorithmManager = new AlgorithmManager([new RS256]);
+    $jwsBuilder = new JWSBuilder($algorithmManager);
+
+    $jws = $jwsBuilder->create()
+        ->withPayload(json_encode($payload))
+        ->addSignature($this->jwk_1, ['alg' => 'RS256', 'kid' => $this->jwk_1->get('kid')])
+        ->build();
+
+    $serializer = new CompactSerializer;
+    $token = $serializer->serialize($jws, 0);
+
+    $this->withHeaders([
+        ZeroTrustMiddleware::CF_ACCESS_JWT_HEADER_NAME => $token,
+    ])
+        ->getJson('/')
+        ->assertStatus(401);
+});
+
+it('rejects user JWT missing country claim', function (): void {
+    $this->withHeaders([
+        ZeroTrustMiddleware::CF_ACCESS_JWT_HEADER_NAME => $this->generateUserJWT('aud', now()->addYear(), $this->jwk_1, ['country' => null]),
+    ])
+        ->getJson('/')
+        ->assertStatus(401);
+});
+
+it('allows service token without nbf claim', function (): void {
+    $payload = [
+        'aud' => ['aud'],
+        'exp' => now()->addYear()->timestamp,
+        'iat' => now()->subSecond()->timestamp,
+        'iss' => 'https://'.config('cloudflare-zero-trust-middleware.cloudflare_team_name').'.cloudflareaccess.com',
+        'type' => 'app',
+        'sub' => '',
+        'common_name' => 'test-service-token.access',
+    ];
+
+    $algorithmManager = new AlgorithmManager([new RS256]);
+    $jwsBuilder = new JWSBuilder($algorithmManager);
+
+    $jws = $jwsBuilder->create()
+        ->withPayload(json_encode($payload))
+        ->addSignature($this->jwk_1, ['alg' => 'RS256', 'kid' => $this->jwk_1->get('kid')])
+        ->build();
+
+    $serializer = new CompactSerializer;
+    $token = $serializer->serialize($jws, 0);
+
+    $this->withHeaders([
+        ZeroTrustMiddleware::CF_ACCESS_JWT_HEADER_NAME => $token,
+    ])
+        ->getJson('/')
+        ->assertStatus(200);
+});
+
+it('allows service token without country claim', function (): void {
+    $payload = [
+        'aud' => ['aud'],
+        'exp' => now()->addYear()->timestamp,
+        'iat' => now()->subSecond()->timestamp,
+        'iss' => 'https://'.config('cloudflare-zero-trust-middleware.cloudflare_team_name').'.cloudflareaccess.com',
+        'type' => 'app',
+        'sub' => '',
+        'common_name' => 'test-service-token.access',
+    ];
+
+    $algorithmManager = new AlgorithmManager([new RS256]);
+    $jwsBuilder = new JWSBuilder($algorithmManager);
+
+    $jws = $jwsBuilder->create()
+        ->withPayload(json_encode($payload))
+        ->addSignature($this->jwk_1, ['alg' => 'RS256', 'kid' => $this->jwk_1->get('kid')])
+        ->build();
+
+    $serializer = new CompactSerializer;
+    $token = $serializer->serialize($jws, 0);
+
+    $this->withHeaders([
+        ZeroTrustMiddleware::CF_ACCESS_JWT_HEADER_NAME => $token,
+    ])
+        ->getJson('/')
+        ->assertStatus(200);
+});
+
+it('allows service token without email claim', function (): void {
+    $payload = [
+        'aud' => ['aud'],
+        'exp' => now()->addYear()->timestamp,
+        'iat' => now()->subSecond()->timestamp,
+        'iss' => 'https://'.config('cloudflare-zero-trust-middleware.cloudflare_team_name').'.cloudflareaccess.com',
+        'type' => 'app',
+        'sub' => '',
+        'common_name' => 'test-service-token.access',
+    ];
+
+    $algorithmManager = new AlgorithmManager([new RS256]);
+    $jwsBuilder = new JWSBuilder($algorithmManager);
+
+    $jws = $jwsBuilder->create()
+        ->withPayload(json_encode($payload))
+        ->addSignature($this->jwk_1, ['alg' => 'RS256', 'kid' => $this->jwk_1->get('kid')])
+        ->build();
+
+    $serializer = new CompactSerializer;
+    $token = $serializer->serialize($jws, 0);
+
+    $this->withHeaders([
+        ZeroTrustMiddleware::CF_ACCESS_JWT_HEADER_NAME => $token,
+    ])
+        ->getJson('/')
+        ->assertStatus(200);
+});
+
+it('allows service token without identity_nonce claim', function (): void {
+    $payload = [
+        'aud' => ['aud'],
+        'exp' => now()->addYear()->timestamp,
+        'iat' => now()->subSecond()->timestamp,
+        'iss' => 'https://'.config('cloudflare-zero-trust-middleware.cloudflare_team_name').'.cloudflareaccess.com',
+        'type' => 'app',
+        'sub' => '',
+        'common_name' => 'test-service-token.access',
+    ];
+
+    $algorithmManager = new AlgorithmManager([new RS256]);
+    $jwsBuilder = new JWSBuilder($algorithmManager);
+
+    $jws = $jwsBuilder->create()
+        ->withPayload(json_encode($payload))
+        ->addSignature($this->jwk_1, ['alg' => 'RS256', 'kid' => $this->jwk_1->get('kid')])
+        ->build();
+
+    $serializer = new CompactSerializer;
+    $token = $serializer->serialize($jws, 0);
+
+    $this->withHeaders([
+        ZeroTrustMiddleware::CF_ACCESS_JWT_HEADER_NAME => $token,
+    ])
+        ->getJson('/')
+        ->assertStatus(200);
+});
+
+it('rejects service token missing common_name claim', function (): void {
+    $this->withHeaders([
+        ZeroTrustMiddleware::CF_ACCESS_JWT_HEADER_NAME => $this->generateServiceTokenJWT('aud', now()->addYear(), $this->jwk_1, ['common_name' => null]),
     ])
         ->getJson('/')
         ->assertStatus(401);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -108,6 +108,113 @@ class TestCase extends Orchestra
         return $serializer->serialize($jws, 0);
     }
 
+    protected function generateUserJWT(string $aud, \Carbon\Carbon $expires, JWK $key, ?array $overrides = null): string
+    {
+        $payload = [
+            'aud' => [$aud],
+            'email' => 'user@example.com',
+            'exp' => $expires->timestamp,
+            'iat' => now()->subSecond()->timestamp,
+            'nbf' => now()->subSecond()->timestamp,
+            'iss' => 'https://'.config('cloudflare-zero-trust-middleware.cloudflare_team_name').'.cloudflareaccess.com',
+            'type' => 'user',
+            'identity_nonce' => 'nonce123',
+            'sub' => 'user-sub-123',
+            'country' => 'US',
+        ];
+
+        if ($overrides !== null) {
+            foreach ($overrides as $overrideKey => $overrideValue) {
+                if ($overrideValue === null) {
+                    unset($payload[$overrideKey]);
+                } else {
+                    $payload[$overrideKey] = $overrideValue;
+                }
+            }
+        }
+
+        $algorithmManager = new AlgorithmManager([new RS256]);
+        $jwsBuilder = new JWSBuilder($algorithmManager);
+
+        $jws = $jwsBuilder->create()
+            ->withPayload(json_encode($payload))
+            ->addSignature($key, ['alg' => 'RS256', 'kid' => $key->get('kid')])
+            ->build();
+
+        $serializer = new CompactSerializer;
+
+        return $serializer->serialize($jws, 0);
+    }
+
+    protected function generateAppJWT(string $aud, \Carbon\Carbon $expires, JWK $key, ?array $overrides = null): string
+    {
+        $payload = [
+            'aud' => [$aud],
+            'exp' => $expires->timestamp,
+            'iat' => now()->subSecond()->timestamp,
+            'iss' => 'https://'.config('cloudflare-zero-trust-middleware.cloudflare_team_name').'.cloudflareaccess.com',
+            'type' => 'app',
+            'identity_nonce' => 'app-nonce-456',
+        ];
+
+        if ($overrides !== null) {
+            foreach ($overrides as $overrideKey => $overrideValue) {
+                if ($overrideValue === null) {
+                    unset($payload[$overrideKey]);
+                } else {
+                    $payload[$overrideKey] = $overrideValue;
+                }
+            }
+        }
+
+        $algorithmManager = new AlgorithmManager([new RS256]);
+        $jwsBuilder = new JWSBuilder($algorithmManager);
+
+        $jws = $jwsBuilder->create()
+            ->withPayload(json_encode($payload))
+            ->addSignature($key, ['alg' => 'RS256', 'kid' => $key->get('kid')])
+            ->build();
+
+        $serializer = new CompactSerializer;
+
+        return $serializer->serialize($jws, 0);
+    }
+
+    protected function generateServiceTokenJWT(string $aud, \Carbon\Carbon $expires, JWK $key, ?array $overrides = null): string
+    {
+        $payload = [
+            'aud' => [$aud],
+            'exp' => $expires->timestamp,
+            'iat' => now()->subSecond()->timestamp,
+            'iss' => 'https://'.config('cloudflare-zero-trust-middleware.cloudflare_team_name').'.cloudflareaccess.com',
+            'type' => 'app',
+            'sub' => '',
+            'common_name' => 'test-service-token.access',
+        ];
+
+        if ($overrides !== null) {
+            foreach ($overrides as $overrideKey => $overrideValue) {
+                if ($overrideValue === null) {
+                    unset($payload[$overrideKey]);
+                } else {
+                    $payload[$overrideKey] = $overrideValue;
+                }
+            }
+        }
+
+        $algorithmManager = new AlgorithmManager([new RS256]);
+        $jwsBuilder = new JWSBuilder($algorithmManager);
+
+        $jws = $jwsBuilder->create()
+            ->withPayload(json_encode($payload))
+            ->addSignature($key, ['alg' => 'RS256', 'kid' => $key->get('kid')])
+            ->build();
+
+        $serializer = new CompactSerializer;
+
+        return $serializer->serialize($jws, 0);
+    }
+
     protected function generateJwtFromUnknownKey(string $aud, \Carbon\Carbon $expires)
     {
         $key = JWKFactory::createRSAKey(

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -146,40 +146,6 @@ class TestCase extends Orchestra
         return $serializer->serialize($jws, 0);
     }
 
-    protected function generateAppJWT(string $aud, \Carbon\Carbon $expires, JWK $key, ?array $overrides = null): string
-    {
-        $payload = [
-            'aud' => [$aud],
-            'exp' => $expires->timestamp,
-            'iat' => now()->subSecond()->timestamp,
-            'iss' => 'https://'.config('cloudflare-zero-trust-middleware.cloudflare_team_name').'.cloudflareaccess.com',
-            'type' => 'app',
-            'identity_nonce' => 'app-nonce-456',
-        ];
-
-        if ($overrides !== null) {
-            foreach ($overrides as $overrideKey => $overrideValue) {
-                if ($overrideValue === null) {
-                    unset($payload[$overrideKey]);
-                } else {
-                    $payload[$overrideKey] = $overrideValue;
-                }
-            }
-        }
-
-        $algorithmManager = new AlgorithmManager([new RS256]);
-        $jwsBuilder = new JWSBuilder($algorithmManager);
-
-        $jws = $jwsBuilder->create()
-            ->withPayload(json_encode($payload))
-            ->addSignature($key, ['alg' => 'RS256', 'kid' => $key->get('kid')])
-            ->build();
-
-        $serializer = new CompactSerializer;
-
-        return $serializer->serialize($jws, 0);
-    }
-
     protected function generateServiceTokenJWT(string $aud, \Carbon\Carbon $expires, JWK $key, ?array $overrides = null): string
     {
         $payload = [


### PR DESCRIPTION
We use Service Tokens for backend services that talk to each other. This PR allows for both user tokens and service tokens based on the content of the JWT passed in.

https://developers.cloudflare.com/cloudflare-one/access-controls/service-credentials/service-tokens/