### PR TITLE
Add Laravel 13 support and drop 11 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,14 +17,14 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: ['8.3', '8.4']
-        laravel: ['12.*', '11.*']
+        php: ['8.3', '8.4', '8.5']
+        laravel: ['13.*','12.*']
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: '11.*'
-            testbench: '9.*'
           - laravel: '12.*'
             testbench: '10.*'
+          - laravel: '13.*'
+            testbench: '11.*'
 
     name: PHP${{ matrix.php }} - Laravel${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^8.3",
         "guzzlehttp/guzzle": "^7.5",
-        "illuminate/contracts": "^11.0|^12.0",
+        "illuminate/contracts": "^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.19",
         "symfony/clock": "^7.3",
         "web-token/jwt-library": "^3.4|^4.0"
@@ -31,12 +31,12 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-deprecation-rules": "^2.0",
-        "pestphp/pest-plugin-laravel": "^3.1",
-        "orchestra/testbench": "^10.0||^9.0",
+        "pestphp/pest-plugin-laravel": "^3.1||^4.0",
+        "orchestra/testbench": "^10.0||^11.0",
         "laravel/pint": "^1.17",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
-        "pestphp/pest": "^3.7",
-        "pestphp/pest-plugin-arch": "^3.0",
+        "pestphp/pest": "^3.7||^4.0",
+        "pestphp/pest-plugin-arch": "^3.0||^4.0",
         "phpstan/extension-installer": "^1.3",
         "spatie/laravel-ray": "^1.35"
     },


### PR DESCRIPTION
This PR introduces support for Laravel 13 and supporting packages. It drops support for Laravel 11 now it is in end of life. PHP versions are left at 8.2 minimum, and tests are added for 8.5.